### PR TITLE
Update deploy workflow with key injection

### DIFF
--- a/.github/workflows/encrypt-and-deploy.yml
+++ b/.github/workflows/encrypt-and-deploy.yml
@@ -31,10 +31,20 @@ jobs:
         run: |
           node .github/scripts/encrypt.js
 
-      - name: Commit encrypted file
+      - name: Inject secret key into script
+        run: sed -i "s|<CLÉ_HEX_A_REMPLACER>|$YAML_ENCRYPT_KEY|" public/script.js
+        env:
+          YAML_ENCRYPT_KEY: ${{ secrets.YAML_ENCRYPT_KEY }}
+
+      - name: Commit encrypted file and script
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add public/parcours.enc
+          git add public/parcours.enc public/script.js
           git commit -m "🔐 Mise à jour du fichier chiffré"
           git push
+
+      - name: Reset key placeholder
+        run: sed -i "s|$YAML_ENCRYPT_KEY|<CLÉ_HEX_A_REMPLACER>|" public/script.js
+        env:
+          YAML_ENCRYPT_KEY: ${{ secrets.YAML_ENCRYPT_KEY }}


### PR DESCRIPTION
## Summary
- update encrypt workflow to inject the encryption key into `public/script.js`
- commit both the encrypted YAML file and updated script
- reset the placeholder key after committing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f482b8d508330aa3a885baf67db47