### PR TITLE
Add permissions to workflow

### DIFF
--- a/.github/workflows/encrypt-and-deploy.yml
+++ b/.github/workflows/encrypt-and-deploy.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   encrypt-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
## Summary
- add `contents: write` permissions to the encrypt workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a8c06208330a5056002b56f216c